### PR TITLE
Set up CI build for merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: "CI Pipeline"
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Solves #13 

We had added CI pipeline for PRs in #15. 

This PR runs same check, on the `main` branch after merge to `main`.