### PR TITLE
Setup basic CD pipeline for GitHub Pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,24 +1,36 @@
-name: "CI Pipeline"
+name: "CD Pipeline"
 on:
-  pull_request:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true # cancel existing runs if PR has been updated -- cost savings
 
 jobs:
-  ci_pipeline:
-    name: "CI Pipeline"
+  build_and_deploy:
+    name: "Build & Deploy Static Assets to GH Pages"
     runs-on: "ubuntu-latest"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Setup Node JS
         uses: actions/setup-node@v4
         with:
           node-version-file: "./.nvmrc"
+
       - name: Install Dependencies
         run: npm install
+
       - name: Build for production
         run: npm run build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build


### PR DESCRIPTION
Addresses #17.

Uses a ready-made action to overwrite `gh-pages` branch content.