### PR TITLE
Add write permissions to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   build_and_deploy:
+    permissions: write-all
     name: "Build & Deploy Static Assets to GH Pages"
     runs-on: "ubuntu-latest"
 


### PR DESCRIPTION
After merging #18, `main` deploy pipeline failed due to insufficient permissions of the `GITHUB_TOKEN`.

[This PR fixes it by manually elevating privilege of the token as documented](https://docs.github.com/en/actions/tutorials/use-github_token-in-workflows#modifying-the-permissions-for-the-github_token).